### PR TITLE
支持英文系统微信 - 窗口标题可配置

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,6 +113,7 @@ rpa:
     room_input_confirm_box: Weixin
     search_contact_window: Weixin
     public_announcement_suffix: 的群公告
+    yuanbao: 元宝
 
 
 wxgf:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -100,8 +100,8 @@ rpa:
   long_term_rate: 0.25
   long_term_capacity: 10
   window_titles:
-    main: WeChat
-    preview: 预览  
+    main: 微信
+    preview: 预览
     add_friend: 通过朋友验证
     invite_member: 微信添加群成员
     remove_member: 微信移出群成员

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,13 +2,16 @@ dbkey:   # 数据库加密密钥，必须设置
 
 # 用户和微信相关设置
 user:
+  # 备用用户信息配置 - 当微信版本变化导致内存读取失败时使用
+  # 如果系统无法从微信进程内存中获取用户信息，将使用以下配置作为备用方案
+  # 注意：系统会优先尝试从微信进程内存中读取真实信息，只有失败时才会使用这些备用配置
   fallback_user_info:
-    account: 微信号
-    alias: 昵称
-    nickname: 机器人
-    phone: ""
-    data_dir: 'C:\path\to\wechat\data'
-    avatar_url: ""
+    account: 微信号          # 备用微信账号，当内存读取失败时使用
+    alias: 昵称             # 备用用户别名/昵称
+    nickname: 机器人         # 备用显示昵称，建议设置为机器人相关名称
+    phone: ""              # 备用手机号，可以为空
+    data_dir: 'C:\path\to\wechat\data'  # 备用微信数据目录路径，请修改为实际路径
+    avatar_url: ""         # 备用头像URL，可以为空
 
 
 # AES加密用的密钥和XOR，格式为字符串, 设置为空，自动查找
@@ -99,21 +102,23 @@ rpa:
   short_term_capacity: 2
   long_term_rate: 0.25
   long_term_capacity: 10
+  # 窗口标题配置 - 用于微信不同语言窗口的标题匹配
+  # 当微信版本更新或者语言更改导致窗口标题变化时，可以通过修改这些配置来适配
   window_titles:
-    main: 微信
-    preview: 预览
-    add_friend: 通过朋友验证
-    invite_member: 微信添加群成员
-    remove_member: 微信移出群成员
-    invite_confirm: Weixin
-    invite_reason: Weixin
-    search_history: 搜索聊天记录
-    friend: 朋友圈
-    menu_window: Weixin
-    room_input_confirm_box: Weixin
-    search_contact_window: Weixin
-    public_announcement_suffix: 的群公告
-    yuanbao: 元宝
+    main: 微信  # 微信主窗口标题
+    preview: 预览  # 预览窗口标题
+    add_friend: 通过朋友验证  # 添加好友验证窗口标题
+    invite_member: 微信添加群成员  # 邀请群成员窗口标题
+    remove_member: 微信移出群成员  # 移出群成员窗口标题
+    invite_confirm: Weixin  # 邀请确认弹窗标题
+    invite_reason: Weixin  # 邀请原因弹窗标题
+    search_history: 搜索聊天记录  # 搜索聊天记录窗口标题
+    friend: 朋友圈  # 朋友圈窗口标题
+    menu_window: Weixin  # 菜单弹窗标题
+    room_input_confirm_box: Weixin  # 群聊输入确认弹窗标题
+    search_contact_window: Weixin  # 搜索联系人弹窗标题
+    public_announcement_suffix: 的群公告  # 群公告窗口标题后缀
+    yuanbao: 元宝  # 元宝窗口标题（AI助手窗口）
 
 
 wxgf:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,16 @@
 dbkey:   # 数据库加密密钥，必须设置
 
+# 用户和微信相关设置
+user:
+  fallback_user_info:
+    account: 微信号
+    alias: 昵称
+    nickname: 机器人
+    phone: ""
+    data_dir: 'C:\path\to\wechat\data'
+    avatar_url: ""
+
+
 # AES加密用的密钥和XOR，格式为字符串, 设置为空，自动查找
 # 示例：aes_xor_key: 1234567890,17
 aes_xor_key: 
@@ -88,6 +99,21 @@ rpa:
   short_term_capacity: 2
   long_term_rate: 0.25
   long_term_capacity: 10
+  window_titles:
+    main: WeChat
+    preview: 预览  
+    add_friend: 通过朋友验证
+    invite_member: 微信添加群成员
+    remove_member: 微信移出群成员
+    invite_confirm: Weixin
+    invite_reason: Weixin
+    search_history: 搜索聊天记录
+    friend: 朋友圈
+    menu_window: Weixin
+    room_input_confirm_box: Weixin
+    search_contact_window: Weixin
+    public_announcement_suffix: 的群公告
+
 
 wxgf:
   # 微信GF解析API地址，暂时未开放，查看roammap更新计划

--- a/src/omni_bot_sdk/bot.py
+++ b/src/omni_bot_sdk/bot.py
@@ -66,14 +66,18 @@ class Bot:
         self._status_callbacks = []  # 状态变更回调列表
 
         # 用户服务与用户信息初始化
-        self.user_service: UserService = UserService(self.config.get("dbkey"), self.config.get("user"))
+        self.user_service: UserService = UserService(
+            self.config.get("dbkey"), self.config.get("user")
+        )
         self.user_info: UserInfo = self.user_service.get_user_info()
         allow_versions = ["4.0.6.33"]
         if self.user_info.version not in allow_versions:
             self.logger.error(
                 f"当前微信版本不在支持范围内,目前支持的版本包括：{','.join(allow_versions)}"
             )
-            self.logger.info("您可以前往：https://github.com/cscnk52/wechat-windows-versions/releases 下载历史版本微信")
+            self.logger.info(
+                "您可以前往：https://github.com/cscnk52/wechat-windows-versions/releases 下载历史版本微信"
+            )
             exit(1)
         # 数据库服务初始化（需最先初始化）
         self.db: DatabaseService = DatabaseService(self.user_service)

--- a/src/omni_bot_sdk/bot.py
+++ b/src/omni_bot_sdk/bot.py
@@ -66,7 +66,7 @@ class Bot:
         self._status_callbacks = []  # 状态变更回调列表
 
         # 用户服务与用户信息初始化
-        self.user_service: UserService = UserService(self.config.get("dbkey"))
+        self.user_service: UserService = UserService(self.config.get("dbkey"), self.config.get("user"))
         self.user_info: UserInfo = self.user_service.get_user_info()
         allow_versions = ["4.0.6.33"]
         if self.user_info.version not in allow_versions:

--- a/src/omni_bot_sdk/rpa/window_manager.py
+++ b/src/omni_bot_sdk/rpa/window_manager.py
@@ -61,9 +61,9 @@ class WindowTitleEnum(Enum):
     窗口标题配置键名枚举
     用于从config中获取对应的窗口标题列表
     """
-    
+
     MAIN = "main"
-    PREVIEW = "preview" 
+    PREVIEW = "preview"
     ADD_FRIEND = "add_friend"
     INVITE_MEMBER = "invite_member"
     REMOVE_MEMBER = "remove_member"
@@ -131,7 +131,7 @@ class WindowManager:
             self.rpa_config.get("search_contact_offset", (0, 40))
         )
         self.color_ranges = self.rpa_config.get("color_ranges", {})
-        
+
         # 获取可配置的窗口标题
         self.window_titles = self.rpa_config.get("window_titles", {})
 
@@ -151,7 +151,7 @@ class WindowManager:
             WindowTitleEnum.ROOM_INPUT_CONFIRM_BOX: "Weixin",
             WindowTitleEnum.SEARCH_CONTACT_WINDOW: "Weixin",
             WindowTitleEnum.PUBLIC_ANNOUNCEMENT_SUFFIX: "的群公告",
-            WindowTitleEnum.YUANBAO: "元宝"
+            WindowTitleEnum.YUANBAO: "元宝",
         }
         return self.window_titles.get(title_key.value, defaults.get(title_key, ""))
 
@@ -159,7 +159,7 @@ class WindowManager:
         """检查窗口标题是否匹配配置的标题"""
         expected_title = self.get_window_title(title_key)
         return window_title == expected_title
-    
+
     def _title_endswith(self, window_title: str, title_key: WindowTitleEnum) -> bool:
         """检查窗口标题是否以指定后缀结尾"""
         suffix = self.get_window_title(title_key)
@@ -215,21 +215,21 @@ class WindowManager:
                     windows = pyautogui.getWindowsWithTitle(main_title)
                     if windows:
                         main_window = windows[0]
-                    
+
                     if main_window:
                         self.weixin_windows[main_title] = {
                             "window": main_window,
-                        "MSG_TOP_X": self.MSG_TOP_X,
-                        "MSG_TOP_Y": self.MSG_TOP_Y,
-                        "MSG_WIDTH": self.MSG_WIDTH,
-                        "MSG_HEIGHT": self.MSG_HEIGHT,
-                        "region": [
-                            0,
-                            0,
-                            self.size_config.width,
-                            self.size_config.height,
-                        ],
-                    }
+                            "MSG_TOP_X": self.MSG_TOP_X,
+                            "MSG_TOP_Y": self.MSG_TOP_Y,
+                            "MSG_WIDTH": self.MSG_WIDTH,
+                            "MSG_HEIGHT": self.MSG_HEIGHT,
+                            "region": [
+                                0,
+                                0,
+                                self.size_config.width,
+                                self.size_config.height,
+                            ],
+                        }
                     return True
                 return False
             else:
@@ -643,14 +643,14 @@ class WindowManager:
         for window in windows:
             if self._title_matches(window.title, WindowTitleEnum.PREVIEW):
                 window.close()
-        
+
         # 尝试找到主窗口
         chat_window = None
         main_title = self.get_window_title(WindowTitleEnum.MAIN)
         windows_with_title = pyautogui.getWindowsWithTitle(main_title)
         if windows_with_title:
             chat_window = windows_with_title[0]
-        
+
         if chat_window:
             self._activate_window(chat_window.title)
             if reposition:
@@ -940,11 +940,15 @@ class WindowManager:
                     return window
         elif windowType == WindowTypeEnum.PublicAnnouncementWindow:
             for window in filter_windows:
-                if self._title_endswith(window.title, WindowTitleEnum.PUBLIC_ANNOUNCEMENT_SUFFIX):
+                if self._title_endswith(
+                    window.title, WindowTitleEnum.PUBLIC_ANNOUNCEMENT_SUFFIX
+                ):
                     return window
         elif windowType == WindowTypeEnum.RoomInputConfirmBox:
             for window in filter_windows:
-                if self._title_matches(window.title, WindowTitleEnum.ROOM_INPUT_CONFIRM_BOX):
+                if self._title_matches(
+                    window.title, WindowTitleEnum.ROOM_INPUT_CONFIRM_BOX
+                ):
                     if (
                         window.left + window.width < self.size_config.width
                         and window.top + window.height < self.size_config.height
@@ -957,7 +961,9 @@ class WindowManager:
                         return window
         elif windowType == WindowTypeEnum.SearchContactWindow:
             for window in filter_windows:
-                if self._title_matches(window.title, WindowTitleEnum.SEARCH_CONTACT_WINDOW):
+                if self._title_matches(
+                    window.title, WindowTitleEnum.SEARCH_CONTACT_WINDOW
+                ):
                     # 这里固定在左上角，所以要判断以下开始位置在左上角
                     if (
                         window.left < self.SIDE_BAR_WIDTH

--- a/src/omni_bot_sdk/rpa/window_manager.py
+++ b/src/omni_bot_sdk/rpa/window_manager.py
@@ -75,6 +75,7 @@ class WindowTitleEnum(Enum):
     ROOM_INPUT_CONFIRM_BOX = "room_input_confirm_box"
     SEARCH_CONTACT_WINDOW = "search_contact_window"
     PUBLIC_ANNOUNCEMENT_SUFFIX = "public_announcement_suffix"
+    YUANBAO = "yuanbao"  # 元宝窗口
 
 
 class WindowManager:
@@ -149,7 +150,8 @@ class WindowManager:
             WindowTitleEnum.MENU_WINDOW: "Weixin",
             WindowTitleEnum.ROOM_INPUT_CONFIRM_BOX: "Weixin",
             WindowTitleEnum.SEARCH_CONTACT_WINDOW: "Weixin",
-            WindowTitleEnum.PUBLIC_ANNOUNCEMENT_SUFFIX: "的群公告"
+            WindowTitleEnum.PUBLIC_ANNOUNCEMENT_SUFFIX: "的群公告",
+            WindowTitleEnum.YUANBAO: "元宝"
         }
         return self.window_titles.get(title_key.value, defaults.get(title_key, ""))
 
@@ -513,8 +515,9 @@ class WindowManager:
     def init_split_sessions(self):
         """初始化分割的会话"""
         windows = pyautogui.getAllWindows()
+        yuanbao_title = self.get_window_title(WindowTitleEnum.YUANBAO)
         for window in windows:
-            if "元宝" in window.title:
+            if yuanbao_title in window.title:
                 self.logger.info("元宝窗口独立设置")
                 self.weixin_windows[window.title] = {
                     "window": window,
@@ -669,8 +672,10 @@ class WindowManager:
             self.logger.error("微信窗口未找到，请检查微信是否正常运行")
             return False
 
-    def _activate_window(self, title: str = "WeChat"):
+    def _activate_window(self, title: str = None):
         """激活微信窗口"""
+        if title is None:
+            title = self.get_window_title(WindowTitleEnum.MAIN)
         try:
             window = pyautogui.getWindowsWithTitle(title)[0]
             window.activate()
@@ -1037,6 +1042,7 @@ class WindowManager:
         关闭所有窗口
         """
         windows = pyautogui.getAllWindows()
+        main_title = self.get_window_title(WindowTitleEnum.MAIN)
         # 这里保留全部符合的窗口
         for window in windows:
             # 对所有的窗口进行过滤，排除掉不可见的，尺寸为0的
@@ -1044,7 +1050,7 @@ class WindowManager:
                 # 这一步要过滤一下非微信的窗口
                 class_name = win32gui.GetClassName(window._hWnd)
                 if class_name.startswith("Qt5"):
-                    if window.title != "WeChat":
+                    if window.title != main_title:
                         window.close()
 
     def open_close_sidebar(self, close: bool = False) -> bool:

--- a/src/omni_bot_sdk/rpa/window_manager.py
+++ b/src/omni_bot_sdk/rpa/window_manager.py
@@ -40,7 +40,7 @@ class WindowTypeEnum(Enum):
     似乎微信4.x 的类名都是 Qt51514QWindowIcon，切记不可直接用类名，万一更新Qt版本就完蛋拉~
     """
 
-    MainWindow = "MainWindow"  # <Win32Window left="0", top="0", width="1008", height="1360", title="WeChat">
+    MainWindow = "MainWindow"  # <Win32Window left="0", top="0", width="1008", height="1360", title="微信">
     InviteMemberWindow = "InviteMemberWindow"  # <Win32Window left="34", top="310", width="938", height="738", title="微信添加群成员">
     InviteConfirmWindow = "InviteConfirmWindow"  # <Win32Window left="298", top="536", width="413", height="288", title="Weixin">
     InviteResonWindow = "InviteResonWindow"  # <Win32Window left="298", top="505", width="413", height="350", title="Weixin">


### PR DESCRIPTION
适配英文系统下的微信，英文系统下设置改了简体中文但是无法更改窗口标题文字，解决因窗口标题不同导致的功能失效问题。

## 主要改动

### 1. 窗口管理系统重构
- 移除所有硬编码的窗口标题
- 添加 `WindowTitleEnum` 枚举管理窗口类型
- 支持通过配置文件自定义所有窗口标题

### 2. 用户服务增强
- UserService 支持接受配置参数，当内存读取失败时使用
- 改进错误处理和容错机制

### 3. 配置文件更新
- 新增 `rpa.window_titles` 配置块，包含15个窗口标题配置项
- 为所有新配置项添加详细注释说明
- 简化用户配置结构

## 配置示例

```yaml
rpa:
  window_titles:
    main: WeChat              # 英文系统使用 "WeChat"
    # ... 其他配置项
```

## 向后兼容

- 保持所有现有功能不变
- 默认使用中文窗口标题，现有用户无需修改配置

## 文件变更

- `src/omni_bot_sdk/rpa/window_manager.py`: 重构窗口管理逻辑
- `src/omni_bot_sdk/services/core/user_service.py`: 增强用户服务
- `src/omni_bot_sdk/bot.py`: 更新配置传递逻辑
- `config.example.yaml`: 添加窗口标题配置和注释